### PR TITLE
Added transfer of RAD tokens to ScopeLift upon successful upgrade to governor Bravo

### DIFF
--- a/script/DeployInput.sol
+++ b/script/DeployInput.sol
@@ -10,5 +10,5 @@ contract DeployInput {
   address constant SCOPELIFT_ADDRESS = 0x5C04E7808455ee0e22c2773328C151d0DD79dC62;
 
   // Number of RAD tokens to transfer to ScopeLift upon upgrade execution
-  uint256 constant SCOPELIFT_AMOUNT = 5000e18;
+  uint256 constant SCOPELIFT_PAYMENT = 5000e18;
 }

--- a/script/DeployInput.sol
+++ b/script/DeployInput.sol
@@ -5,4 +5,10 @@ contract DeployInput {
   uint256 constant INITIAL_VOTING_DELAY = 7200; // 24 hours
   uint256 constant INITIAL_VOTING_PERIOD = 17_280; // matches existing config
   uint256 constant INITIAL_PROPOSAL_THRESHOLD = 1_000_000e18; // matches existing config
+
+  // ScopeLift address for receiving the RAD tokens upon upgrade execution
+  address constant SCOPELIFT_ADDRESS = 0x5C04E7808455ee0e22c2773328C151d0DD79dC62;
+
+  // Number of RAD tokens to transfer to ScopeLift upon upgrade execution
+  uint256 constant SCOPELIFT_AMOUNT = 5000e18;
 }

--- a/script/Propose.s.sol
+++ b/script/Propose.s.sol
@@ -24,7 +24,7 @@ contract Propose is Script, Constants, DeployInput {
     _targets[0] = RAD_TOKEN;
     _values[0] = 0;
     _signatures[0] = "transfer(address,uint256)";
-    _calldatas[0] = abi.encode(SCOPELIFT_ADDRESS, SCOPELIFT_AMOUNT);
+    _calldatas[0] = abi.encode(SCOPELIFT_ADDRESS, SCOPELIFT_PAYMENT);
 
     _targets[1] = RADWORK_GOVERNOR_ALPHA.timelock();
     _values[1] = 0;

--- a/script/Propose.s.sol
+++ b/script/Propose.s.sol
@@ -8,27 +8,33 @@ import {ICompoundTimelock} from
 import {RadworksGovernor} from "src/RadworksGovernor.sol";
 import {IGovernorAlpha} from "src/interfaces/IGovernorAlpha.sol";
 import {Constants} from "test/Constants.sol";
+import {DeployInput} from "script/DeployInput.sol";
 
 /// @notice Script to submit the proposal to upgrade Radworks governor.
-contract Propose is Script, Constants {
+contract Propose is Script, Constants, DeployInput {
   IGovernorAlpha constant RADWORK_GOVERNOR_ALPHA = IGovernorAlpha(GOVERNOR_ALPHA);
   address PROPOSER_ADDRESS = 0x464D78a5C97A2E2E9839C353ee9B6d4204c90B0b; // cloudhead.eth
 
   function propose(RadworksGovernor _newGovernor) internal returns (uint256 _proposalId) {
-    address[] memory _targets = new address[](2);
-    uint256[] memory _values = new uint256[](2);
-    string[] memory _signatures = new string[](2);
-    bytes[] memory _calldatas = new bytes[](2);
+    address[] memory _targets = new address[](3);
+    uint256[] memory _values = new uint256[](3);
+    string[] memory _signatures = new string[](3);
+    bytes[] memory _calldatas = new bytes[](3);
 
-    _targets[0] = RADWORK_GOVERNOR_ALPHA.timelock();
+    _targets[0] = RAD_TOKEN;
     _values[0] = 0;
-    _signatures[0] = "setPendingAdmin(address)";
-    _calldatas[0] = abi.encode(address(_newGovernor));
+    _signatures[0] = "transfer(address,uint256)";
+    _calldatas[0] = abi.encode(SCOPELIFT_ADDRESS, SCOPELIFT_AMOUNT);
 
-    _targets[1] = address(_newGovernor);
+    _targets[1] = RADWORK_GOVERNOR_ALPHA.timelock();
     _values[1] = 0;
-    _signatures[1] = "__acceptAdmin()";
-    _calldatas[1] = "";
+    _signatures[1] = "setPendingAdmin(address)";
+    _calldatas[1] = abi.encode(address(_newGovernor));
+
+    _targets[2] = address(_newGovernor);
+    _values[2] = 0;
+    _signatures[2] = "__acceptAdmin()";
+    _calldatas[2] = "";
 
     return RADWORK_GOVERNOR_ALPHA.propose(
       _targets, _values, _signatures, _calldatas, "Upgrade to Governor Bravo"

--- a/test/RadworksGovernor.t.sol
+++ b/test/RadworksGovernor.t.sol
@@ -71,7 +71,7 @@ abstract contract Propose is ProposalTest {
     uint256 _seed
   ) public {
     IERC20 _token = _randomERC20Token(_seed);
-    // @dev: RAD_TOKEN handled in seperate test because bravo upgrade changes RAD token balances
+    // RAD_TOKEN handled in seperate test because bravo upgrade changes RAD token balances
     vm.assume(_token != IERC20(RAD_TOKEN));
     _assumeReceiver(_receiver);
     uint256 _timelockTokenBalance = _token.balanceOf(TIMELOCK);
@@ -101,14 +101,14 @@ abstract contract Propose is ProposalTest {
   function testFuzz_NewGovernorCanPassProposalToSendRadTokens(uint256 _amount, address _receiver)
     public
   {
-    // @dev: RAD_TOKEN handled specially as bravo upgrade changes RAD token balances
+    // RAD_TOKEN handled specially as bravo upgrade changes RAD token balances
     IERC20 _token = IERC20(RAD_TOKEN);
     _assumeReceiver(_receiver);
     uint256 _timelockTokenBalance = _token.balanceOf(TIMELOCK);
 
     // bound by the number of tokens the timelock currently controls
     // (less the amount to be sent to ScopeLift on the Bravo upgrade)
-    _amount = bound(_amount, 0, _timelockTokenBalance - SCOPELIFT_AMOUNT);
+    _amount = bound(_amount, 0, _timelockTokenBalance - SCOPELIFT_PAYMENT);
     uint256 _initialTokenBalance = _token.balanceOf(_receiver);
 
     _upgradeToBravoGovernor();
@@ -126,7 +126,7 @@ abstract contract Propose is ProposalTest {
 
     // Ensure the tokens have been transferred
     assertEq(_token.balanceOf(_receiver), _initialTokenBalance + _amount);
-    assertEq(_token.balanceOf(TIMELOCK), _timelockTokenBalance - (_amount + SCOPELIFT_AMOUNT));
+    assertEq(_token.balanceOf(TIMELOCK), _timelockTokenBalance - (_amount + SCOPELIFT_PAYMENT));
   }
 
   function testFuzz_NewGovernorCanPassProposalToSendETH(uint256 _amount, address _receiver) public {
@@ -163,7 +163,7 @@ abstract contract Propose is ProposalTest {
     uint256 _seed
   ) public {
     IERC20 _token = _randomERC20Token(_seed);
-    // @dev: RAD_TOKEN handled in seperate test because bravo upgrade changes RAD token balances
+    // RAD_TOKEN handled in separate test because bravo upgrade changes RAD token balances
     vm.assume(_token != IERC20(RAD_TOKEN));
     _assumeReceiver(_receiver);
 
@@ -197,7 +197,7 @@ abstract contract Propose is ProposalTest {
       _values,
       _calldatas,
       "Transfer tokens and ETH via the new Governor",
-      FOR // Vote/suppport type.
+      FOR // Vote/support type.
     );
 
     // Ensure the ETH was transferred.
@@ -209,7 +209,7 @@ abstract contract Propose is ProposalTest {
     assertEq(_token.balanceOf(TIMELOCK), _timelockTokenBalance - _amountToken);
   }
 
-  function testFuzz_NewGovernorCanPassProposalToSendETHWithRadTokens(
+  function testFuzz_NewGovernorCanPassProposalToSendETHAndRadTokens(
     uint256 _amountETH,
     uint256 _amountToken,
     address _receiver
@@ -225,7 +225,7 @@ abstract contract Propose is ProposalTest {
     // Bound _amountToken by the number of tokens the timelock currently controls.
     uint256 _timelockTokenBalance = _token.balanceOf(TIMELOCK);
     uint256 _receiverTokenBalance = _token.balanceOf(_receiver);
-    _amountToken = bound(_amountToken, 0, _timelockTokenBalance - SCOPELIFT_AMOUNT);
+    _amountToken = bound(_amountToken, 0, _timelockTokenBalance - SCOPELIFT_PAYMENT);
 
     // Craft a new proposal to send ETH and tokens.
     address[] memory _targets = new address[](2);
@@ -257,7 +257,7 @@ abstract contract Propose is ProposalTest {
 
     // Ensure the tokens were transferred.
     assertEq(_token.balanceOf(_receiver), _receiverTokenBalance + _amountToken);
-    assertEq(_token.balanceOf(TIMELOCK), _timelockTokenBalance - (_amountToken + SCOPELIFT_AMOUNT));
+    assertEq(_token.balanceOf(TIMELOCK), _timelockTokenBalance - (_amountToken + SCOPELIFT_PAYMENT));
   }
 
   function testFuzz_NewGovernorFailedProposalsCantSendETH(uint256 _amount, address _receiver)
@@ -442,7 +442,7 @@ abstract contract Propose is ProposalTest {
     uint256 _timelockTokenBalance = _token.balanceOf(TIMELOCK);
 
     // bound by the number of tokens the timelock currently controls
-    _amount = bound(_amount, 0, _timelockTokenBalance - SCOPELIFT_AMOUNT);
+    _amount = bound(_amount, 0, _timelockTokenBalance - SCOPELIFT_PAYMENT);
     uint256 _initialTokenBalance = _token.balanceOf(_receiver);
 
     _upgradeToBravoGovernor();
@@ -501,7 +501,7 @@ abstract contract Propose is ProposalTest {
 
     // Ensure the tokens have been transferred
     assertEq(_token.balanceOf(_receiver), _initialTokenBalance + _amount);
-    assertEq(_token.balanceOf(TIMELOCK), _timelockTokenBalance - (_amount + SCOPELIFT_AMOUNT));
+    assertEq(_token.balanceOf(TIMELOCK), _timelockTokenBalance - (_amount + SCOPELIFT_PAYMENT));
   }
 
   function testFuzz_NewGovernorCanDefeatMixedProposal(

--- a/test/RadworksGovernor.t.sol
+++ b/test/RadworksGovernor.t.sol
@@ -72,13 +72,12 @@ abstract contract Propose is ProposalTest {
   ) public {
     IERC20 _token = _randomERC20Token(_seed);
     _assumeReceiver(_receiver);
+    _upgradeToBravoGovernor();
     uint256 _timelockTokenBalance = _token.balanceOf(TIMELOCK);
 
     // bound by the number of tokens the timelock currently controls
     _amount = bound(_amount, 0, _timelockTokenBalance);
     uint256 _initialTokenBalance = _token.balanceOf(_receiver);
-
-    _upgradeToBravoGovernor();
 
     (
       address[] memory _targets,
@@ -131,6 +130,7 @@ abstract contract Propose is ProposalTest {
   ) public {
     IERC20 _token = _randomERC20Token(_seed);
     _assumeReceiver(_receiver);
+    _upgradeToBravoGovernor();
 
     vm.deal(TIMELOCK, _amountETH);
     uint256 _timelockETHBalance = TIMELOCK.balance;
@@ -140,8 +140,6 @@ abstract contract Propose is ProposalTest {
     uint256 _timelockTokenBalance = _token.balanceOf(TIMELOCK);
     uint256 _receiverTokenBalance = _token.balanceOf(_receiver);
     _amountToken = bound(_amountToken, 0, _timelockTokenBalance);
-
-    _upgradeToBravoGovernor();
 
     // Craft a new proposal to send ETH and tokens.
     address[] memory _targets = new address[](2);
@@ -280,13 +278,14 @@ abstract contract Propose is ProposalTest {
   ) public {
     IERC20 _token = _randomERC20Token(_seed);
     _assumeReceiver(_receiver);
+    _upgradeToBravoGovernor();
+
     uint256 _timelockTokenBalance = _token.balanceOf(TIMELOCK);
 
     // bound by the number of tokens the timelock currently controls
     _amount = bound(_amount, 0, _timelockTokenBalance);
     uint256 _initialTokenBalance = _token.balanceOf(_receiver);
 
-    _upgradeToBravoGovernor();
     (
       uint256 _newProposalId,
       address[] memory _targets,

--- a/test/RadworksGovernor.t.sol
+++ b/test/RadworksGovernor.t.sol
@@ -148,7 +148,7 @@ abstract contract Propose is ProposalTest {
       _values,
       new bytes[](1), // There is no calldata for a plain ETH call.
       "Transfer some ETH via the new Governor",
-      FOR // Vote/suppport type.
+      FOR // Vote/support type.
     );
 
     // Ensure the ETH was transferred.
@@ -248,7 +248,7 @@ abstract contract Propose is ProposalTest {
       _values,
       _calldatas,
       "Transfer tokens and ETH via the new Governor",
-      FOR // Vote/suppport type.
+      FOR // Vote/support type.
     );
 
     // Ensure the ETH was transferred.

--- a/test/RadworksGovernorAlpha.t.sol
+++ b/test/RadworksGovernorAlpha.t.sol
@@ -24,18 +24,22 @@ abstract contract RadworksGovernorAlphaTest is ProposalTest {
       string[] memory _signatures,
       bytes[] memory _calldatas
     ) = governorAlpha.getActions(upgradeProposalId);
-    assertEq(_targets.length, 2);
-    assertEq(_targets[0], TIMELOCK);
-    assertEq(_targets[1], address(governorBravo));
-    assertEq(_values.length, 2);
+    assertEq(_targets.length, 3);
+    assertEq(_targets[0], RAD_TOKEN);
+    assertEq(_targets[1], TIMELOCK);
+    assertEq(_targets[2], address(governorBravo));
+    assertEq(_values.length, 3);
     assertEq(_values[0], 0);
     assertEq(_values[1], 0);
-    assertEq(_signatures.length, 2);
-    assertEq(_signatures[0], "setPendingAdmin(address)");
-    assertEq(_signatures[1], "__acceptAdmin()");
-    assertEq(_calldatas.length, 2);
-    assertEq(_calldatas[0], abi.encode(address(governorBravo)));
-    assertEq(_calldatas[1], "");
+    assertEq(_values[2], 0);
+    assertEq(_signatures.length, 3);
+    assertEq(_signatures[0], "transfer(address,uint256)");
+    assertEq(_signatures[1], "setPendingAdmin(address)");
+    assertEq(_signatures[2], "__acceptAdmin()");
+    assertEq(_calldatas.length, 3);
+    assertEq(_calldatas[0], abi.encode(SCOPELIFT_ADDRESS, SCOPELIFT_AMOUNT));
+    assertEq(_calldatas[1], abi.encode(address(governorBravo)));
+    assertEq(_calldatas[2], "");
   }
 
   function test_UpgradeProposalActiveAfterDelay() public {
@@ -106,6 +110,10 @@ abstract contract RadworksGovernorAlphaTest is ProposalTest {
   }
 
   function test_UpgradeProposalCanBeExecutedAfterDelay() public {
+    // get the starting Timelock and ScopeLift RAD balances
+    uint256 _timelockRADBalance = ERC20VotesComp(RAD_TOKEN).balanceOf(TIMELOCK);
+    uint256 _scopeLiftRADBalance = ERC20VotesComp(RAD_TOKEN).balanceOf(SCOPELIFT_ADDRESS);
+
     _passAndQueueUpgradeProposal();
     _jumpPastProposalEta();
 
@@ -118,6 +126,18 @@ abstract contract RadworksGovernorAlphaTest is ProposalTest {
 
     // Ensure the governorBravo is now the admin of the timelock
     assertEq(timelock.admin(), address(governorBravo));
+
+    // Ensure the Timelock has transferred the RAD tokens to the ScopeLift address
+    assertEq(
+      ERC20VotesComp(RAD_TOKEN).balanceOf(TIMELOCK),
+      _timelockRADBalance - SCOPELIFT_AMOUNT,
+      "Timelock RAD balance is incorrect"
+    );
+    assertEq(
+      ERC20VotesComp(RAD_TOKEN).balanceOf(SCOPELIFT_ADDRESS),
+      _scopeLiftRADBalance + SCOPELIFT_AMOUNT,
+      "ScopeLift RAD balance is incorrect"
+    );
   }
 
   //
@@ -172,13 +192,13 @@ abstract contract RadworksGovernorAlphaTest is ProposalTest {
     _assumeReceiver(_receiver);
     IERC20 _token = _randomERC20Token(_seed);
 
+    // Pass and execute the proposal to upgrade the Governor
+    _upgradeToBravoGovernor();
+
     uint256 _receiverTokenBalance = _token.balanceOf(_receiver);
     uint256 _timelockTokenBalance = _token.balanceOf(TIMELOCK);
     // bound by the number of tokens the timelock currently controls
     _amount = bound(_amount, 0, _timelockTokenBalance);
-
-    // Pass and execute the proposal to upgrade the Governor
-    _upgradeToBravoGovernor();
 
     // Craft a new proposal to send the token.
     address[] memory _targets = new address[](1);

--- a/test/RadworksGovernorAlpha.t.sol
+++ b/test/RadworksGovernorAlpha.t.sol
@@ -37,7 +37,7 @@ abstract contract RadworksGovernorAlphaTest is ProposalTest {
     assertEq(_signatures[1], "setPendingAdmin(address)");
     assertEq(_signatures[2], "__acceptAdmin()");
     assertEq(_calldatas.length, 3);
-    assertEq(_calldatas[0], abi.encode(SCOPELIFT_ADDRESS, SCOPELIFT_AMOUNT));
+    assertEq(_calldatas[0], abi.encode(SCOPELIFT_ADDRESS, SCOPELIFT_PAYMENT));
     assertEq(_calldatas[1], abi.encode(address(governorBravo)));
     assertEq(_calldatas[2], "");
   }
@@ -130,12 +130,12 @@ abstract contract RadworksGovernorAlphaTest is ProposalTest {
     // Ensure the Timelock has transferred the RAD tokens to the ScopeLift address
     assertEq(
       ERC20VotesComp(RAD_TOKEN).balanceOf(TIMELOCK),
-      _timelockRADBalance - SCOPELIFT_AMOUNT,
+      _timelockRADBalance - SCOPELIFT_PAYMENT,
       "Timelock RAD balance is incorrect"
     );
     assertEq(
       ERC20VotesComp(RAD_TOKEN).balanceOf(SCOPELIFT_ADDRESS),
-      _scopeLiftRADBalance + SCOPELIFT_AMOUNT,
+      _scopeLiftRADBalance + SCOPELIFT_PAYMENT,
       "ScopeLift RAD balance is incorrect"
     );
   }


### PR DESCRIPTION
This PR implements a transfer of RAD tokens to ScopeLift as part of the transaction that upgrades to Governor Bravo.

Resolves #17 