### PR TITLE
Change to 12 hour voting delay

### DIFF
--- a/script/DeployInput.sol
+++ b/script/DeployInput.sol
@@ -2,7 +2,7 @@
 pragma solidity ^0.8.20;
 
 contract DeployInput {
-  uint256 constant INITIAL_VOTING_DELAY = 7200; // 24 hours
+  uint256 constant INITIAL_VOTING_DELAY = 3600; // 12 hours
   uint256 constant INITIAL_VOTING_PERIOD = 17_280; // matches existing config
   uint256 constant INITIAL_PROPOSAL_THRESHOLD = 1_000_000e18; // matches existing config
 


### PR DESCRIPTION
As requested by Radworks, a 12 hour voting delay at deployment